### PR TITLE
Add normally distributed error, update classifier

### DIFF
--- a/binaryclassifier/EmulatorMain.py
+++ b/binaryclassifier/EmulatorMain.py
@@ -7,9 +7,14 @@ Discovery rate ~ 1 transient per 10^6 sources detected per epoch So, transient d
 
 Each object contains a semi-random number of observations (2-10). Observations come in tuples of (time (seconds), light (no idea)). 
 Objects are arrays of these tuples where the first index is the first observation taken.
+
+added normally distributed error instead of random error between +-5%.
+right now the error has a mean of (lightvalue) and a standard deviation of (lightvalue*.05)
+this means roughly 68% of light values will be +-5%, while 32% will be more extreme outliers 
 """
 
 from collections import namedtuple
+import numpy.random
 import random
 
 class EmulatorMain(object):
@@ -36,7 +41,7 @@ class EmulatorMain(object):
             point = namedtuple('Observation' + str(x), ['time', 'light'])
             if isTransient == False:
                 timeTaken = timeTaken + timeInterval
-                p = point(timeTaken, (initialBrightness + createError()))
+                p = point(timeTaken, initialBrightness + createError(initialBrightness))
                 finalObject.append(p)
                 continue
             if hasSlopeChanged == False:
@@ -49,7 +54,7 @@ class EmulatorMain(object):
             else:
                 initialBrightness = initialBrightness - variance
             timeTaken = timeTaken + timeInterval;
-            p = point(timeTaken, (initialBrightness + createError()))            
+            p = point(timeTaken, initialBrightness + createError(initialBrightness))            
             finalObject.append(p)
             
         return finalObject
@@ -61,15 +66,11 @@ class EmulatorMain(object):
         Returns ? Do we even need this?
         """
       
-def createError():
-    # Error between -5%-5% of value passsed in (random)
-    observationalError = random.randint(-5, 5)
-    observationalError = observationalError * .01
+def createError(light):
+    #Normally distributed error
+    s = numpy.random.normal(light, abs(light * .02) + .0001) #about 68% of values will be within +-.02*light
+    if random.getrandbits(1) == True:
+        observationalError = light - s
+    else:
+        observationalError = s - light
     return observationalError
-
-"""#CODE TO PRINT OUT OBSERVATIONS OF A SINGLE OBJECT
-a = EmulatorMain()
-h = a.generateSingleObject(True)
-for a in h:
-    print a
-"""

--- a/binaryclassifier/SimpleClassifier.py
+++ b/binaryclassifier/SimpleClassifier.py
@@ -37,17 +37,20 @@ def classify_simple(observations):
 
     for i in slopeList:
         sum = sum + i
-
+    
+    errorAccount = False
     averageSlope = sum / len(slopeList)
-    errorAccountLow = averageSlope - .08
-    errorAccountHigh = averageSlope + .08
+    errorAccountLow = averageSlope - (averageSlope * .06)
+    errorAccountHigh = averageSlope + (averageSlope * .06)
     for i in slopeList:
         if i > high:
             high = i
         if i < low:
             low = i
-        if (i < errorAccountLow) or (i > errorAccountHigh):
+        if (i < errorAccountLow) or (i > errorAccountHigh) and (errorAccount == True):
             return True
+        else:
+            errorAccount = True
     if (high > errorAccountHigh) or (low < errorAccountLow):
         return True
     else:

--- a/meta.yaml
+++ b/meta.yaml
@@ -8,20 +8,23 @@ source:
 requirements:
   build:
     - python
+    - numpy
     - setuptools ==27.2.0
 
   run:
     - python
+    - numpy
     - pycli
 
 test:
   requires:
+    - python
+    - numpy
     - nose
 
   files:
     - binaryclassifier
-    - tests/test_EmulatorMain.py
-    - tests/test_main.py
+    - tests
 
 about:
   home: https://github.com/CSC380Team8/binary-classifier

--- a/tests/test_EmulatorMain.py
+++ b/tests/test_EmulatorMain.py
@@ -1,7 +1,0 @@
-from binaryclassifier import EmulatorMain
-
-def test_createError():
-    for x in range(0, 100):
-        error = EmulatorMain.createError()
-        print error # Show value in case of test failure
-        assert error >= -0.05 and error <= 0.05


### PR DESCRIPTION
Added normally distributed error instead of random error between +-5%. Right now the error has a mean of (lightvalue) and a standard deviation of (lightvalue*.05) this means roughly 68% of light values will be +-5%, while 32% will be more extreme outliers.

Fixed emulator, improved the classifier to handle normally distributed error